### PR TITLE
switch to using Email.smtpClient only in tests

### DIFF
--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -297,7 +297,7 @@ func TestEmailSendBufferClientError(t *testing.T) {
 	assert.NoError(t, e.sendBuffer(context.Background(), []emailMessage{{}}), "",
 		"no error expected for e.sendBuffer with	 failed smtpClient.Quit but successful smtpClient.Close")
 	e.smtpClient = nil
-	assert.EqualError(t, e.sendEmail(emailMessage{}), "sendEmail called without smtpClient set",
+	assert.EqualError(t, e.sendEmail(emailMessage{}, e.smtpClient), "sendEmail called without smtpClient set",
 		"e.sendEmail called without smtpClient set returns error")
 }
 


### PR DESCRIPTION
Current implementation of Email implies that it will create new
connection for every batch sending, however does not deliver this
promise and will leave the connection present but in closed state,
not trying to re-establish it on the second run.

Email.smtpClient in current setup makes all sending functions
thread-unsafe which is also is not good and easy to fix by not using it.

This can be resolved by:

1. Setting Email.smtpClient pointer to nil after each use.
Still thread-unsafe, and this will make testing send of multiple email
batches impossible as after we'll pass test connection for the first
time, it will be closed by the second batch send and real connection
would be tried to be established.

2. Not saving the connection anywhere at all, allowing change of
Email.smtpClient only to test code.
Current commit variant. Email.smtpClient is the only way I could think
of of delivering the fake smtpClient to send function.

I would love to find a more elegant way to inject the fakeSMTP object,
however so far that's the only way I found.